### PR TITLE
Enable ssl connections on local files

### DIFF
--- a/app/core/repositories/uploaderLocalRepository.js
+++ b/app/core/repositories/uploaderLocalRepository.js
@@ -17,7 +17,7 @@ const UploaderRepository = (folder) => {
                 const {authorization, host} = headers;
 
                 resolve({
-                    signedRequest: `http://${host}/users/upload?ext=${mapsFile(type)}&folder=${folder}`,
+                    signedRequest: `//${host}/users/upload?ext=${mapsFile(type)}&folder=${folder}`,
                     filename: `${folder}/${filename}`,
                     headers: {"Content-type": CONTENT_UPLOAD_DEFAULT, "Authorization": authorization}
                 });

--- a/server.js
+++ b/server.js
@@ -19,5 +19,5 @@ process.env.MAESTRO_PORT = process.env.MAESTRO_PORT || 8888;
 server = http.createServer(app);
 server.listen(process.env.MAESTRO_PORT);
 server.on('listening', function () {
-    console.log('Maestro: Server listening on http://localhost:%d', this.address().port);
+    console.log('Maestro: Server listening on //localhost:%d', this.address().port);
 });


### PR DESCRIPTION
Enabling ssl connections on local file upload.

Fixing the issue [client-app/issues/9](https://github.com/maestro-server/client-app/issues/9)